### PR TITLE
(SIMP-398) Eliminate all uses of lsb* facts

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,52 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+    gem 'simp-rake-helpers'
+  end
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-aide.spec
+++ b/build/pupmod-aide.spec
@@ -7,7 +7,6 @@ Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-auditd >= 4.1.0-3
-Requires: pupmod-common >= 4.1.0-7
 Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-logrotate >= 4.1.0-0
 Requires: pupmod-rsyslog >= 5.0.0

--- a/manifests/add_rules.pp
+++ b/manifests/add_rules.pp
@@ -29,7 +29,7 @@ define aide::add_rules (
   $rules,
   $ruledir = '/etc/aide.conf.d'
 ) {
-  file { "$ruledir/$name.aide":
+  file { "${ruledir}/${name}.aide":
     ensure  => 'present',
     owner   => 'root',
     group   => 'root',
@@ -40,8 +40,8 @@ define aide::add_rules (
   }
 
   # Add auditing rules for the aide configuration.
-  auditd::add_rules { "$name.aide":
-    content => "-w $ruledir/$name.aide -p wa -k CFG_aide"
+  auditd::add_rules { "${name}.aide":
+    content => "-w ${ruledir}/${name}.aide -p wa -k CFG_aide"
   }
 
   validate_absolute_path($ruledir)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,14 +178,14 @@ class aide (
       killall -9 aide;
       wait;
 
-      if [ -f $dbdir/$database_name ]; then
+      if [ -f ${dbdir}/${database_name} ]; then
         /bin/nice -n 19 /usr/sbin/aide -c /etc/aide.conf -u;
       else
         /bin/nice -n 19 /usr/sbin/aide -c /etc/aide.conf -i;
       fi
 
       wait;
-      mv $dbdir/$database_out_name $dbdir/$database_name"
+      mv ${dbdir}/${database_out_name} ${dbdir}/${database_name}"
   }
 
   # CCE-27135-3
@@ -201,7 +201,7 @@ class aide (
 
   exec { 'verify_aide_db_presence':
     command => '/usr/local/sbin/update_aide &',
-    onlyif  => "/usr/bin/test ! -f $dbdir/$database_name",
+    onlyif  => "/usr/bin/test ! -f ${dbdir}/${database_name}",
     require => [
       File['/usr/local/sbin/update_aide'],
       File[$dbdir],

--- a/manifests/logrotate.pp
+++ b/manifests/logrotate.pp
@@ -22,8 +22,8 @@ class aide::logrotate (
 
   logrotate::add { 'aide':
     log_files     => [
-      "$::aide::logdir/*.report",
-      "$::aide::logdir/*.log"
+      "${::aide::logdir}/*.report",
+      "${::aide::logdir}/*.log"
     ],
     missingok     => true,
     rotate_period => $rotate_period,

--- a/manifests/to_syslog.pp
+++ b/manifests/to_syslog.pp
@@ -33,11 +33,11 @@ class aide::to_syslog (
   rsyslog::rule::other { 'aide_log':
     rule    =>
 "input(type=\"imfile\"
-  File=\"$logdir/aide.log\"
+  File=\"${logdir}/aide.log\"
   StateFile=\"aide_log\"
   Tag=\"tag_aide_log\"
-  Severity=\"$log_severity\"
-  Facility=\"$log_facility\"
+  Severity=\"${log_severity}\"
+  Facility=\"${log_facility}\"
 )",
     require => File[$logdir]
   }
@@ -45,11 +45,11 @@ class aide::to_syslog (
   rsyslog::rule::other { 'aide_report':
     rule    =>
 "input(type=\"imfile\"
-  File=\"$logdir/aide.report\"
+  File=\"${logdir}/aide.report\"
   Tag=\"tag_aide_report\"
   StateFile=\"aide_report\"
-  Severity=\"$log_severity\"
-  Facility=\"$log_facility\"
+  Severity=\"${log_severity}\"
+  Facility=\"${log_facility}\"
 )",
     require => File[$logdir]
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,41 @@
+{
+  "name":    "simp-aide",
+  "version": "4.1.0",
+  "author":  "simp",
+  "summary": "manages AIDE",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-aide",
+  "project_page": "https://github.com/simp/pupmod-simp-aide",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "aide" ],
+  "dependencies": [
+    {
+      "name": "simp-auditd",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-logrotate",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-rsyslog",
+      "version_requirement": ">= 5.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/default_rules_spec.rb
+++ b/spec/classes/default_rules_spec.rb
@@ -8,7 +8,7 @@ describe 'aide::default_rules' do
 
     it { should create_class('aide::default_rules') }
 
-    context "#{factgroup[:operatingsystem]} #{factgroup[:lsbmajdistrelease]}" do
+    context "#{factgroup[:operatingsystem]} #{factgroup[:operatingsystemmajrelease]}" do
       it { should compile.with_all_deps }
       it { should create_file('/etc/aide.conf.d/default.aide').with_content(/\/bin\s+NORMAL/) }
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,7 +9,7 @@ describe 'aide' do
 
     it { should create_class('aide') }
 
-    context "#{factgroup[:operatingsystem]} #{factgroup[:lsbmajdistrelease]}" do
+    context "#{factgroup[:operatingsystem]} #{factgroup[:operatingsystemmajrelease]}" do
       it { should compile.with_all_deps }
       it { should contain_class('aide::default_rules') }
       it { should_not contain_class('aide::set_schedule') }

--- a/spec/classes/logrotate_spec.rb
+++ b/spec/classes/logrotate_spec.rb
@@ -8,7 +8,7 @@ describe 'aide::logrotate' do
     let(:facts) {factgroup}
     it { should create_class('aide::logrotate') }
 
-    context "#{factgroup[:operatingsystem]} #{factgroup[:lsbmajdistrelease]}" do
+    context "#{factgroup[:operatingsystem]} #{factgroup[:operatingsystemmajrelease]}" do
       it { should compile.with_all_deps }
     end
   end

--- a/spec/classes/set_schedule_spec.rb
+++ b/spec/classes/set_schedule_spec.rb
@@ -7,7 +7,7 @@ describe 'aide::set_schedule' do
   FactGroups.factgroups.each do |factgroup|
     let(:facts) {factgroup}
 
-    context "#{factgroup[:operatingsystem]} #{factgroup[:lsbmajdistrelease]}" do
+    context "#{factgroup[:operatingsystem]} #{factgroup[:operatingsystemmajrelease]}" do
       it { should create_class('aide::set_schedule') }
       it { should compile.with_all_deps }
       it { should contain_cron('aide_schedule') }

--- a/spec/classes/to_syslog_spec.rb
+++ b/spec/classes/to_syslog_spec.rb
@@ -9,7 +9,7 @@ describe 'aide::to_syslog' do
 
     it { should create_class('aide::to_syslog') }
 
-    context "#{factgroup[:operatingsystem]} #{factgroup[:lsbmajdistrelease]}" do
+    context "#{factgroup[:operatingsystem]} #{factgroup[:operatingsystemmajrelease]}" do
       it { should compile.with_all_deps }
       it { should contain_class('rsyslog') }
     end

--- a/spec/defines/add_rules_spec.rb
+++ b/spec/defines/add_rules_spec.rb
@@ -10,7 +10,7 @@ describe 'aide::add_rules' do
   FactGroups.factgroups.each do |factgroup|
     let(:facts) {factgroup}
 
-    context "#{factgroup[:operatingsystem]} #{factgroup[:lsbmajdistrelease]}" do
+    context "#{factgroup[:operatingsystem]} #{factgroup[:operatingsystemmajrelease]}" do
       it { should compile.with_all_deps }
       it { should create_file('/etc/aide.conf.d/test_rules.aide').with_content(/test_rules/) }
     end

--- a/spec/fact_groups_helper.rb
+++ b/spec/fact_groups_helper.rb
@@ -14,19 +14,19 @@ module FactGroups
     factgroups = [
       {
         :operatingsystem => 'RedHat',
-        :lsbmajdistrelease => '7'
+        :operatingsystemmajrelease => '7'
       },
       {
         :operatingsystem => 'RedHat',
-        :lsbmajdistrelease => '6'
+        :operatingsystemmajrelease => '6'
       },
       {
         :operatingsystem => 'CentOS',
-        :lsbmajdistrelease => '7'
+        :operatingsystemmajrelease => '7'
       },
       {
         :operatingsystem => 'CentOS',
-        :lsbmajdistrelease => '6'
+        :operatingsystemmajrelease => '6'
       },
     ]
 


### PR DESCRIPTION
This commit replaces all `lsb*` facts with their (package-independant)
`operatingsystem*` counterparts.  Common module assets have also been
normalized.

SIMP-666 #close
SIMP-398 #comment updated `pupmod-simp-aide`
SIMP-667 #comment updated `pupmod-simp-aide`
