### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,9 @@
-Requires: pupmod-simp-auditd >= 4.1.0-3
-Requires: pupmod-simp-compliance_markup
-Requires: pupmod-simp-logrotate >= 4.1.0-0
-Requires: pupmod-simp-rsyslog >= 5.0.0
 Obsoletes: pupmod-aide-test
+Requires: pupmod-simp-auditd < 6.0.0-0
+Requires: pupmod-simp-auditd >= 5.0.4-0
+Requires: pupmod-simp-compliance_markup < 2.0.0-0
+Requires: pupmod-simp-compliance_markup >= 1.0.1-0
+Requires: pupmod-simp-logrotate < 5.0.0-0
+Requires: pupmod-simp-logrotate >= 4.1.0-0
+Requires: pupmod-simp-rsyslog < 6.0.0-0
+Requires: pupmod-simp-rsyslog >= 5.1.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-aide",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "author": "simp",
   "summary": "manages AIDE",
   "license": "Apache-2.0",
@@ -14,19 +14,19 @@
   "dependencies": [
     {
       "name": "simp/auditd",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 5.0.4 < 6.0.0"
     },
     {
       "name": "simp/logrotate",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.1.0 < 5.0.0"
     },
     {
       "name": "simp/rsyslog",
-      "version_requirement": ">= 5.0.0"
+      "version_requirement": ">= 5.1.0 < 6.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-aide`
SIMP-1620 #close