### PR TITLE
(SIMP-6116) Replace Puppet 3 validate_between

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.2-0
+- Replace use of simplib's deprecated Puppet 3 validate_between
+  with Simplib::Cron::* types.  This change allows more flexibility
+  in cron scheduling.
+
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.1-0
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.md

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,32 +95,32 @@
 # @author https://github.com/simp/pupmod-simp-aide/graphs/contributors
 #
 class aide (
-  Array[String]                              $aliases,          # data in modules
-  Stdlib::Absolutepath                       $dbdir             = '/var/lib/aide',
-  Stdlib::Absolutepath                       $logdir            = '/var/log/aide',
-  String                                     $database_name     = 'aide.db.gz',
-  String                                     $database_out_name = 'aide.db.new.gz',
-  Variant[Enum['yes','no'],Boolean]          $gzip_dbout        = 'yes',
-  Stdlib::Compat::Integer                    $verbose           = '5',
-  Array[String]                              $report_urls       = [ 'file:@@{LOGDIR}/aide.report'],
-  Stdlib::Absolutepath                       $ruledir           = '/etc/aide.conf.d',
-  Array[String]                              $rules             = [ 'default.aide' ],
-  Boolean                                    $enable            = false,
-  Stdlib::Compat::Integer                    $minute            = 22,
-  Stdlib::Compat::Integer                    $hour              = 4,
-  Variant[Enum['*'],Stdlib::Compat::Integer] $monthday          = '*',
-  Variant[Enum['*'],Stdlib::Compat::Integer] $month             = '*',
-  Stdlib::Compat::Integer                    $weekday           = 0,
-  String                                     $cron_command      = '/bin/nice -n 19 /usr/sbin/aide -C',
-  String                                     $default_rules     = '', # lint:ignore:empty_string_assignment
-  Boolean                                    $logrotate         = simplib::lookup('simp_options::logrotate', { 'default_value' => false}),
-  Aide::Rotateperiod                         $rotate_period     = 'weekly',
-  Integer                                    $rotate_number     = 4,
-  Boolean                                    $syslog            = simplib::lookup('simp_options::syslog', { 'default_value'    => false }),
-  Aide::SyslogFacility                       $syslog_facility   = 'LOG_LOCAL6',
-  Boolean                                    $auditd            = simplib::lookup('simp_options::auditd', { 'default_value'    => false }),
-  Integer                                    $aide_init_timeout = 300,
-  String                                     $package_ensure    = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  Array[String]                     $aliases,          # data in modules
+  Stdlib::Absolutepath              $dbdir             = '/var/lib/aide',
+  Stdlib::Absolutepath              $logdir            = '/var/log/aide',
+  String                            $database_name     = 'aide.db.gz',
+  String                            $database_out_name = 'aide.db.new.gz',
+  Variant[Enum['yes','no'],Boolean] $gzip_dbout        = 'yes',
+  Stdlib::Compat::Integer           $verbose           = '5',
+  Array[String]                     $report_urls       = [ 'file:@@{LOGDIR}/aide.report'],
+  Stdlib::Absolutepath              $ruledir           = '/etc/aide.conf.d',
+  Array[String]                     $rules             = [ 'default.aide' ],
+  Boolean                           $enable            = false,
+  Simplib::Cron::Minute             $minute            = 22,
+  Simplib::Cron::Hour               $hour              = 4,
+  Simplib::Cron::Monthday           $monthday          = '*',
+  Simplib::Cron::Month              $month             = '*',
+  Simplib::Cron::Weekday            $weekday           = 0,
+  String                            $cron_command      = '/bin/nice -n 19 /usr/sbin/aide -C',
+  String                            $default_rules     = '', # lint:ignore:empty_string_assignment
+  Boolean                           $logrotate         = simplib::lookup('simp_options::logrotate', { 'default_value' => false}),
+  Aide::Rotateperiod                $rotate_period     = 'weekly',
+  Integer                           $rotate_number     = 4,
+  Boolean                           $syslog            = simplib::lookup('simp_options::syslog', { 'default_value'    => false }),
+  Aide::SyslogFacility              $syslog_facility   = 'LOG_LOCAL6',
+  Boolean                           $auditd            = simplib::lookup('simp_options::auditd', { 'default_value'    => false }),
+  Integer                           $aide_init_timeout = 300,
+  String                            $package_ensure    = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
 
   include '::aide::default_rules'

--- a/manifests/set_schedule.pp
+++ b/manifests/set_schedule.pp
@@ -12,18 +12,14 @@
 # @author https://github.com/simp/pupmod-simp-aide/graphs/contributors
 #
 class aide::set_schedule (
-  Stdlib::Compat::Integer                    $minute   = $::aide::minute,
-  Stdlib::Compat::Integer                    $hour     = $::aide::hour,
-  Variant[Enum['*'],Stdlib::Compat::Integer] $monthday = $::aide::monthday,
-  Variant[Enum['*'],Stdlib::Compat::Integer] $month    = $::aide::month,
-  Stdlib::Compat::Integer                    $weekday  = $::aide::weekday,
-  String                                     $command  = $::aide::cron_command,
+  Simplib::Cron::Minute   $minute   = $::aide::minute,
+  Simplib::Cron::Hour     $hour     = $::aide::hour,
+  Simplib::Cron::Monthday $monthday = $::aide::monthday,
+  Simplib::Cron::Month    $month    = $::aide::month,
+  Simplib::Cron::Weekday  $weekday  = $::aide::weekday,
+  String                  $command  = $::aide::cron_command,
 ) {
   assert_private()
-
-  validate_between($minute, 0, 60)
-  validate_between($hour, 0, 24)
-  validate_between($weekday, 0, 7)
 
   cron { 'aide_schedule':
     command  => $command,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-aide",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "author": "SIMP Team",
   "summary": "manages AIDE",
   "license": "Apache-2.0",
@@ -26,7 +26,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.14.1 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Replace use of simplib's deprecated Puppet 3 validate_between
with Simplib::Cron::* types.  This change allows more flexibility
in cron scheduling.

SIMP-6116 #close