### PR TITLE
Automatically add `@@include` lines to aide.conf

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,6 +7,7 @@ fixtures:
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     cron_core: https://github.com/puppetlabs/puppetlabs-cron_core
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
+    concat: https://github.com/simp/puppetlabs-concat
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pki: https://github.com/simp/pupmod-simp-pki
@@ -18,6 +19,3 @@ fixtures:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7
       branch: master
       target: spec/fixtures/inspec_deps/inspec_profiles/profiles
-
-  symlinks:
-    aide: "#{source_dir}"

--- a/manifests/default_rules.pp
+++ b/manifests/default_rules.pp
@@ -25,6 +25,7 @@ class aide::default_rules (
 
   aide::rule { 'default':
     ruledir => $ruledir,
-    rules   => $_rules
+    rules   => $_rules,
+    order   => '002',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.12.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     }
   ],
   "simp": {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,7 +23,9 @@ describe 'aide' do
           it { is_expected.to contain_file('/etc/aide.conf.d').with_ensure('directory') }
           it { is_expected.to contain_file('/var/lib/aide').with_ensure('directory') }
           it { is_expected.to contain_file('/var/log/aide').with_ensure('directory') }
-          it { is_expected.to contain_file('/etc/aide.conf').with_content(<<EOM
+          it { is_expected.to contain_concat('/etc/aide.conf') }
+          it { is_expected.to contain_concat__fragment('aide.conf').with_target('/etc/aide.conf') }
+          it { is_expected.to contain_concat__fragment('aide.conf').with_content(<<EOM
 @@define DBDIR /var/lib/aide
 @@define LOGDIR /var/log/aide
 database=file:@@{DBDIR}/aide.db.gz
@@ -44,7 +46,6 @@ LOG = >
 LSPP = R
 DATAONLY = p+n+u+g+s+acl+selinux+xattrs+sha1+sha256
 
-@@include /etc/aide.conf.d/default.aide
 EOM
           ) }
 
@@ -96,11 +97,11 @@ EOM
             :weekday  => '0'
           } ) }
 
-          it{ is_expected.to contain_file('/etc/aide.conf').with_content(
+          it{ is_expected.to contain_concat__fragment('aide.conf').with_content(
             /report_url=file:@@{LOGDIR}\/aide.report/ )
           }
 
-          it{ is_expected.to contain_file('/etc/aide.conf').with_content(
+          it{ is_expected.to contain_concat__fragment('aide.conf').with_content(
             /report_url=syslog:LOG_LOCAL6/ )
           }
 
@@ -141,7 +142,7 @@ EOM
 
         context 'with default parameters' do
           it { is_expected.to create_class('aide') }
-          it { is_expected.to contain_file('/etc/aide.conf').with_content(<<EOM
+          it { is_expected.to contain_concat__fragment('aide.conf').with_content(<<EOM
 @@define DBDIR /var/lib/aide
 @@define LOGDIR /var/log/aide
 database=file:@@{DBDIR}/aide.db.gz
@@ -162,7 +163,6 @@ LOG = >
 LSPP = R
 DATAONLY = p+n+u+g+s+acl+selinux+xattrs+sha512
 
-@@include /etc/aide.conf.d/default.aide
 EOM
           ) }
         end

--- a/templates/aide.conf.erb
+++ b/templates/aide.conf.erb
@@ -12,6 +12,3 @@ report_url=<%= report_url %>
 <%= a %>
 <% end -%>
 
-<% @rules.each do |rule| -%>
-@@include <%= @ruledir %>/<%= rule %>
-<% end -%>


### PR DESCRIPTION
Before this commit, when declaring `aide::rule` resources, it was also
necessary to add the rule name to the `$aide::rules` array.

By switching to using `concat` this is no longer necessary.  Instead the
`rules` parameter is repurposed to accept a hash of `aide::rule`
resources.  The old behaviour is deprecated, and this change shouldn't
be breaking.