### PR TITLE
[SIMP-MAINT] Fix the EL8 compliance ciphers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-* Fri Apr 10 2020 Trevor Vaughan <tvaughan@onyxpoint.com> 6.4.1-0
+* Wed Apr 29 2020 Trevor Vaughan <tvaughan@onyxpoint.com> 6.4.1-0
+- Update the EL8 ciphers to be safe on FIPS systems by default
+  - Do not use the built-in aliases
 - Remove overrides for aide::aliases on EL8 since it works properly in FIPS mode
 
 * Wed Feb 12 2020 Alexander Fisher <alex@linfratech.co.uk> 6.4.1-0

--- a/SIMP/compliance_profiles/checks.yaml
+++ b/SIMP/compliance_profiles/checks.yaml
@@ -127,13 +127,13 @@ checks:
       parameter: aide::aliases
       value:
       - ALLXTRAHASHES = sha1+sha256
-      - EVERYTHING = R+ALLXTRAHASHES
-      - NORMAL = R
+      - NORMAL = p+i+l+n+u+g+s+m+c+acl+sha512
+      - EVERYTHING = NORMAL+ALLXTRAHASHES
       - DIR = p+i+n+u+g+acl+xattrs
       - PERMS = p+i+u+g+acl
       - LOG = >
-      - LSPP = R
-      - DATAONLY = p+n+u+g+s+acl+selinux+xattrs+sha1+sha256
+      - LSPP = p+i+l+n+u+g+s+m+c+acl+sha512
+      - DATAONLY = p+n+u+g+s+acl+selinux+xattrs+sha512
     type: puppet-class-parameter
     controls:
       disa_stig: true


### PR DESCRIPTION
- Update the EL8 ciphers to be safe on FIPS systems by default
  - Do not use the built-in aliases