### PR TITLE
(SIMP-8839) Remove EL6 from pupmod-simp-aide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 *.erb eol=lf
 *.pp eol=lf
 *.sh eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-# NOTE: This file is managed by puppetsync.  Make sure any changes are
-#       reflected in the control repo.
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 .*.sw?
 .yardoc
 .idea/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,10 @@
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**
 #
-# Everything above the "Repo-specific content" comment will be overwritten by
-# the next puppetsync.
+# This file is updated automatically as part of a puppet module baseline.
+#
+# The next baseline sync will overwrite any local changes to everything above
+# the line "# Repo-specific content"
 # ------------------------------------------------------------------------------
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
@@ -13,11 +15,10 @@
 # Release       Puppet   Ruby    EOL
 # SIMP 6.4      5.5      2.4.10  TBD
 # PE 2018.1     5.5      2.4.10  2021-01 (LTS overlap)
-# PE 2019.8     6.16     2.5.7   2021-11 (LTS)
+# PE 2019.8     6.18     2.5.7   2022-12 (LTS)
 ---
 
 stages:
-  - 'sanity'
   - 'validation'
   - 'acceptance'
   - 'compliance'
@@ -76,6 +77,9 @@ variables:
     - "{manifests,files,types}/**/*"
     - "templates/*.{erb,epp}"
     - "lib/**/*"
+    - "Gemfile"
+    - "SIMP/**/*"
+    - "data/**/*"
   exists:
     - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*_spec.rb"
 
@@ -87,6 +91,9 @@ variables:
     - "{manifests,files,types}/**/*"
     - "templates/*.{erb,epp}"
     - "lib/**/*"
+    - "Gemfile"
+    - "SIMP/**/*"
+    - "data/**/*"
   exists:
     - "spec/acceptance/**/*_spec.rb"
 
@@ -208,10 +215,10 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_6_16_0: &pup_6_16_0
+.pup_6_18_0: &pup_6_18_0
   image: 'ruby:2.5'
   variables:
-    PUPPET_VERSION: '6.16.0'
+    PUPPET_VERSION: '6.18.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
@@ -251,14 +258,13 @@ variables:
 # Pipeline / testing matrix
 #=======================================================================
 
-sanity_checks:
+releng_checks:
   <<: *pup_5
   <<: *setup_bundler_env
-  stage: 'sanity'
+  stage: 'validation'
   tags: ['docker']
   script:
-    - 'if `hash apt-get`; then apt-get update; fi'
-    - 'if `hash apt-get`; then apt-get install -y rpm; fi'
+    - 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
     - 'bundle exec rake check:dot_underscore'
     - 'bundle exec rake check:test_file'
     - 'bundle exec rake pkg:check_version'
@@ -294,8 +300,8 @@ pup6-unit:
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6.16.0-unit:
-  <<: *pup_6_16_0
+pup6.18.0-unit:
+  <<: *pup_6_18_0
   <<: *unit_tests
 
 # ------------------------------------------------------------------------------
@@ -351,26 +357,26 @@ pup6-compliance:
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
 
-pup6.16.0:
-  <<: *pup_6_16_0
+pup6.18.0:
+  <<: *pup_6_18_0
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default]'
 
-pup6.16.0-fips:
-  <<: *pup_6_16_0
+pup6.18.0-fips:
+  <<: *pup_6_18_0
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
 
-pup6.16.0-oel:
-  <<: *pup_6_16_0
+pup6.18.0-oel:
+  <<: *pup_6_18_0
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup6.16.0-oel-fips:
-  <<: *pup_6_16_0
+pup6.18.0-oel-fips:
+  <<: *pup_6_18_0
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:

--- a/.pmtignore
+++ b/.pmtignore
@@ -1,8 +1,10 @@
 # .pmtignore is required to mask symlinks from the `puppet module build` test
 # In the module's pipeline sanity checks
 # ------------------------------------------------------------------------------
-# NOTE: This file is managed by puppetsync.  Make sure any changes are
-#       reflected in the control repo.
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
 .*.sw?
 .yardoc

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
 --no-class_inherits_from_params_class-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Dec 17 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.4.3
+- Removed EL6 support
+
 * Wed Apr 29 2020 Trevor Vaughan <tvaughan@onyxpoint.com> 6.4.2-0
 - Update the EL8 ciphers to be safe on FIPS systems by default
   - Do not use the built-in aliases

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-aide",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "author": "SIMP Team",
   "summary": "manages AIDE",
   "license": "Apache-2.0",
@@ -45,7 +45,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -53,7 +52,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -61,7 +59,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -6,23 +6,13 @@
   end
 -%>
 HOSTS:
-  el6:
-    roles:
-      - server
-      - default
-      - master
-      - client
-    platform: el-6-x86_64
-    box: centos/6
-    hypervisor: <%= hypervisor %>
-    yum_repos:
-      chef-current:
-        baseurl: 'https://packages.chef.io/repos/yum/current/el/7/$basearch'
-        gpgkeys:
-          - https://packages.chef.io/chef.asc
   el7:
     roles:
       - client
+      # roles migrated from now-removed el6 node(s): 
+      - server
+      - default
+      - master
     platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -6,19 +6,13 @@
   end
 -%>
 HOSTS:
-  oel6:
-    roles:
-      - server
-      - default
-      - master
-      - client
-    platform: el-6-x86_64
-    box: onyxpoint/oel-6-x86_64
-    hypervisor: <%= hypervisor %>
-
   oel7:
     roles:
       - client
+      # roles migrated from now-removed el6 node(s): 
+      - server
+      - default
+      - master
     platform: el-7-x86_64
     box: onyxpoint/oel-7-x86_64
     hypervisor: <%= hypervisor %>


### PR DESCRIPTION
This patch removes EL6 as a supported OS in `metadata.json`, Hiera YAML
files and from the beaker acceptance tests and nodesets.

SIMP-8843 #close
[SIMP-8839] #comment Removed EL6 from pupmod-simp-aide
[SIMP-8489] #comment Updated pupmod-simp-aide GLCI pipeline to Puppet 6.18
[SIMP-8923] #comment Renamed 'sanity' to 'releng' in pupmod-simp-aide

[SIMP-8839]: https://simp-project.atlassian.net/browse/SIMP-8839
[SIMP-8489]: https://simp-project.atlassian.net/browse/SIMP-8489
[SIMP-8923]: https://simp-project.atlassian.net/browse/SIMP-8923