### PR TITLE
(SIMP-9888) Ensure min stdlib is 6.6.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.18.0 < 8.0.0"
+      "version_requirement": ">= 6.6.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
This patch ensures the minimum puppetlabs/stdlib version is `6.6.0`.

[SIMP-9891] #close
[SIMP-9888] #comment pupmod-simp-aide stdlib >= 6.6.0

[SIMP-9891]: https://simp-project.atlassian.net/browse/SIMP-9891
[SIMP-9888]: https://simp-project.atlassian.net/browse/SIMP-9888