### PR TITLE
Update deps to use puppet/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,7 +14,9 @@ fixtures:
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
-    systemd: https://github.com/simp/puppet-systemd.git
+    systemd:
+      repo: https://github.com/simp/puppet-systemd.git
+      branch: simp-master
     disa_stig-el7-baseline:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7.git
       branch: master

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.6.0
+- Update from camptocamp/systemd to puppet/systemd
+
 * Mon Jun 14 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.5.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,7 +140,7 @@ class aide (
   Boolean                                  $syslog            = simplib::lookup('simp_options::syslog', { 'default_value' => false }),
   Aide::SyslogFacility                     $syslog_facility   = 'LOG_LOCAL6',
   Boolean                                  $auditd            = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
-  Integer                                  $aide_init_timeout = 300,
+  Integer                                  $aide_init_timeout = $facts['processorcount'] ? { 1 => 600, default => 300 },
   String                                   $package_ensure    = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,7 +140,7 @@ class aide (
   Boolean                                  $syslog            = simplib::lookup('simp_options::syslog', { 'default_value' => false }),
   Aide::SyslogFacility                     $syslog_facility   = 'LOG_LOCAL6',
   Boolean                                  $auditd            = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
-  Integer                                  $aide_init_timeout = $facts['processorcount'] ? { 1 => 600, default => 300 },
+  Integer                                  $aide_init_timeout = $facts['processorcount'] ? { 1 => 1200, default => 300 },
   String                                   $package_ensure    = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-aide",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "author": "SIMP Team",
   "summary": "manages AIDE",
   "license": "Apache-2.0",
@@ -13,8 +13,8 @@
   ],
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -27,7 +27,6 @@ CONFIG:
   log_level: verbose
   synced_folder : disabled
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -27,6 +27,8 @@ CONFIG:
   log_level: verbose
   synced_folder : disabled
   type: aio
+  # For DB updates
+  vagrant_cpus: 2
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -28,7 +28,6 @@ CONFIG:
   log_level: verbose
   synced_folder : disabled
   type: aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>


### PR DESCRIPTION
This patch updates from camptocamp/systemd 2.x to puppet/systemd 3.x

This bump is driven by simp/simp-core#829