### PR TITLE
Cleanup metadata for 9.0.0 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,8 @@
 - The catalog is noop-safe: `/etc/aide.conf` edits require `Package['aide']`, so
   a `--noop` run on a host without the package reports the pending changes
   instead of failing.
+- Point `issues_url` at GitHub Issues instead of the retired Atlassian instance.
+- Allow `simp-auditd` 10.x as an optional dependency.
 
 * Mon May 11 2026 Steven Pritchard <steve@sicura.us> - 8.0.0
 - Remove unmaintained Compliance Engine data

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-aide",
   "project_page": "https://github.com/simp/pupmod-simp-aide",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-aide/issues",
   "tags": [
     "simp",
     "aide"
@@ -29,7 +29,7 @@
     "optional_dependencies": [
       {
         "name": "simp/auditd",
-        "version_requirement": ">= 8.5.0 < 10.0.0"
+        "version_requirement": ">= 8.5.0 < 11.0.0"
       },
       {
         "name": "simp/logrotate",


### PR DESCRIPTION
## Summary

Small metadata cleanups on top of the 9.0.0 release work already in master:

- Point ` issues_url` at GitHub Issues instead of the retired SIMP Atlassian instance.
- Allow `simp-auditd` 10.x as an optional dependency (10.0.0 is the current major).

The 9.0.0 entry already exists in CHANGELOG; appended two bullets noting these tweaks.

## Test plan
- [x] \`bundle exec rake spec\` (1190 examples, 0 failures, run in ruby:3.2 container)
- [x] \`bundle exec rake metadata_lint\`