### PR TITLE
Add AGENTS.md plumbing and correct CentOS support in the doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,21 @@ dist
 /doc
 /Gemfile.lock
 /Gemfile.local
+
+## AI coding assistant-specific configuration
+## The standard is AGENTS.md
+# Claude Code
 /CLAUDE.md
+/.claude/
+# GitHub Copilot
+/.github/copilot-instructions.md
+# Cursor
+/.cursor/
+/.cursorrules
+# Windsurf
+/.windsurf/
+/.windsurfrules
+# Gemini CLI
+/GEMINI.md
+# Cline
+/.clinerules/

--- a/.pdkignore
+++ b/.pdkignore
@@ -55,3 +55,4 @@
 /spec/
 /.vscode/
 /tests/
+/AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to AI agents when working with code in this repository.
 
-`simp-aide` is a SIMP Puppet module that manages AIDE (Advanced Intrusion Detection Environment). It targets EL8/9/10 (RedHat/CentOS/Alma/Oracle/Rocky) and OpenVox/Puppet 8.
+`simp-aide` is a SIMP Puppet module that manages AIDE (Advanced Intrusion Detection Environment). It targets EL8/9/10 (RedHat/Alma/Oracle/Rocky) plus CentOS 9/10, on OpenVox 8.
 
 ## Ruby / toolchain (read first)
 


### PR DESCRIPTION
Two AGENTS.md-related changes — no manifest or behavior changes:

**AI-assistant plumbing** — the module already ships an `AGENTS.md`; this adds the supporting ignore rules.
- **.gitignore** — replace the lone `/CLAUDE.md` line with the canonical AI coding-assistant block (Claude Code, Copilot, Cursor, Windsurf, Gemini, Cline). `AGENTS.md` is the committed standard; `CLAUDE.md` is a local, uncommitted symlink to it.
- **.pdkignore** — exclude `/AGENTS.md` from built module packages.

**AGENTS.md accuracy fix** — the intro line overclaimed CentOS EL8; `metadata.json` supports CentOS 9/10 only, and declares the OpenVox runtime.

Split out of the original combined PR #168; test hardening lives in #171 (rspec) and #172 (acceptance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
