### PR TITLE
Assert the $_db_notify database-rebuild gating

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -199,6 +199,34 @@ describe 'aide' do
         }
       end
 
+      # The `$_db_notify` gating is a central safety invariant: editing an
+      # aide.conf line must trigger the (disruptive) database rebuild *only*
+      # when the module also owns the database (`manage_database => true`). On a
+      # bare config edit the notify resolves to undef, so no rebuild fires.
+      # Neither direction of this wiring was previously asserted.
+      context 'database-rebuild notification gating' do
+        context 'a config edit with manage_database => false (default)' do
+          let(:params) { { dbdir: '/var/lib/aide' } }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_exec('update_aide_db') }
+
+          it 'does not notify a rebuild from the managed aide.conf line' do
+            expect(catalogue.resource('File_line', 'aide.conf DBDIR')[:notify]).to be_nil
+          end
+        end
+
+        context 'a config edit with manage_database => true' do
+          let(:params) { { dbdir: '/var/lib/aide', manage_database: true } }
+
+          it { is_expected.to compile.with_all_deps }
+
+          it 'notifies the database rebuild from the managed aide.conf line' do
+            is_expected.to contain_file_line('aide.conf DBDIR').that_notifies('Exec[update_aide_db]')
+          end
+        end
+      end
+
       context 'with enable => true' do
         let(:params) { { enable: true } }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -202,18 +202,32 @@ describe 'aide' do
       # The `$_db_notify` gating is a central safety invariant: editing an
       # aide.conf line must trigger the (disruptive) database rebuild *only*
       # when the module also owns the database (`manage_database => true`). On a
-      # bare config edit the notify resolves to undef, so no rebuild fires.
-      # Neither direction of this wiring was previously asserted.
+      # bare config edit the notify resolves to undef, so no rebuild fires. The
+      # genuinely new coverage here is the notify *relationship* in both
+      # directions, checked across two representative managed lines (DBDIR and
+      # database_in) that share the same `notify => $_db_notify` wiring.
       context 'database-rebuild notification gating' do
-        context 'a config edit with manage_database => false (default)' do
+        context 'a DBDIR edit with manage_database => false (default)' do
           let(:params) { { dbdir: '/var/lib/aide' } }
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.not_to contain_exec('update_aide_db') }
 
-          it 'does not notify a rebuild from the managed aide.conf line' do
-            expect(catalogue.resource('File_line', 'aide.conf DBDIR')[:notify]).to be_nil
-          end
+          # `not_to ... that_notifies` passes vacuously if the resource is
+          # absent, so assert the managed line exists before asserting it does
+          # not notify a rebuild.
+          it { is_expected.to contain_file_line('aide.conf DBDIR') }
+          it { is_expected.not_to contain_file_line('aide.conf DBDIR').that_notifies('Exec[update_aide_db]') }
+        end
+
+        context 'a database_in edit with manage_database => false (default)' do
+          let(:params) { { database_in: 'file:@@{DBDIR}/aide.db.gz' } }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_exec('update_aide_db') }
+
+          it { is_expected.to contain_file_line('aide.conf database_in') }
+          it { is_expected.not_to contain_file_line('aide.conf database_in').that_notifies('Exec[update_aide_db]') }
         end
 
         context 'a config edit with manage_database => true' do


### PR DESCRIPTION
Unit-test hardening, split out of the original combined PR #168 per review feedback.

- `spec/classes/init_spec.rb`: assert the `$_db_notify` database-rebuild gating in both directions — a bare config edit with `manage_database => false` must NOT notify a rebuild, and with `manage_database => true` the managed `aide.conf` line must notify `Exec[update_aide_db]`. This central safety invariant was previously unasserted.

Branches off `master`; independent of the AGENTS.md and acceptance PRs (linked below).


## Related PRs (split from #168)
- AGENTS.md plumbing: #170
- rspec coverage: #171
- acceptance suite: #172